### PR TITLE
Add PyQt5

### DIFF
--- a/vma-rvtools-analysis/requirements.txt
+++ b/vma-rvtools-analysis/requirements.txt
@@ -9,3 +9,4 @@ ace_tools>=0.0
 pandoc>=2.4
 tabulate>=0.9.0
 seaborn>=0.13.2
+PyQt5>=5.15.11


### PR DESCRIPTION
Fix clipboard copy/paste errors from Pyperclip when running Notebook
Install PyQt5 as per https://pyperclip.readthedocs.io/en/latest/index.html#not-implemented-error