### PR TITLE
Update running-a-customized-migration.adoc removing duplicate task

### DIFF
--- a/content/modules/ROOT/pages/running-a-customized-migration.adoc
+++ b/content/modules/ROOT/pages/running-a-customized-migration.adoc
@@ -118,10 +118,6 @@ Navigate to the root of the ETX git repository and create a new file called `mig
           ansible.builtin.set_fact:
             plan_vms: "{{ namespace_vms.resources | selectattr('metadata.name', 'in', vm_names) | list }}"
 
-        - name: Set Virtual Machines to Update
-          ansible.builtin.set_fact:
-            plan_vms: "{{ namespace_vms.resources | selectattr('metadata.name', 'in', vm_names) | list }}"
-
         - name: Update MAC Address
           kubernetes.core.k8s_json_patch:
             api_version: "{{ plan_vm.0.apiVersion }}"


### PR DESCRIPTION
# Description
This PR updates the running-a-customized-migration.adoc documentation by removing a duplicate task block that redundantly set the plan_vms variable using the ansible.builtin.set_fact module.

Changes
* Removed the repeated Set Virtual Machines to Update task.

```
- name: Set Virtual Machines to Update
          ansible.builtin.set_fact:
            plan_vms: "{{ namespace_vms.resources | selectattr('metadata.name', 'in', vm_names) | list }}"
```

# Rationale

The duplicated block served no additional purpose and could lead to misunderstandings or maintenance overhead. This update streamlines the task flow and improves readability.